### PR TITLE
Disable memory extractor for emterpreter build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/pypy"]
 	path = deps/pypy
-	url = https://github.com/pypyjs/pypy
+	url = https://github.com/trinketapp/pypy

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/pypy"]
 	path = deps/pypy
-	url = https://github.com/trinketapp/pypy
+	url = https://github.com/pypyjs/pypy

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ release-debug: ./build/pypy-debug.js-$(VERSION).tar.gz
 	mkdir -p $(RELDIR)/lib
 	# Copy the compiled VM and massage it into the expected shape.
 	cp ./build/$*.vm.js $(RELDIR)/lib/pypy.vm.js
-	python ./tools/extract_memory_initializer.py $(RELDIR)/lib/pypy.vm.js
+	# python ./tools/extract_memory_initializer.py $(RELDIR)/lib/pypy.vm.js
 	# Cromulate for better compressibility, unless it's a debug build.
 	if [ `echo $< | grep -- -debug` ]; then true ; else python ./tools/cromulate.py -w 1000 $(RELDIR)/lib/pypy.vm.js ; fi
 	# Copy the supporting JS library code.


### PR DESCRIPTION
Emterpreter requires a separate memory file so extraction is not necessary

see [this](https://github.com/rfk/pypy/pull/3) pypy PR for more info.