### PR TITLE
Consolidate naming of things to "PyPy.js" in text and "pypyjs" in code.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -40,7 +40,7 @@ We have the following major components in the PyPy repo:
 Along with these wrappers to help working with the resulting interpreter:
 
   * A wrapper to load up the compiled VM and expose it via a nice javascript
-    API: `./lib/pypy.js`.
+    API: `./lib/pypyjs.js`.
   * A script for bundling python modules into an indexed format that can be
     easily loaded into the browser:  `./tools/module_bundler.py`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Here you can catch up on the history of the pypyjs project.
 ## 2015-02-23
 [The Emterpreter: Run code before it can be parsed](
 https://blog.mozilla.org/research/2015/02/23/the-emterpreter-run-code-before-it-can-be-parsed/)
--- This may allow us to get pypy.js down to a reasonable size. See [issue #37](https://github.com/rfk/pypyjs/issues/37).
+-- This may allow us to get PyPy.js down to a reasonable size. See [issue #37](https://github.com/rfk/pypyjs/issues/37).
 
 ## 2015-01-28
 [Are we Python yet?](https://www.rfk.id.au/blog/entry/are-we-python-yet/)

--- a/README.dist.rst
+++ b/README.dist.rst
@@ -9,16 +9,16 @@ in pure javascript, either in a browser or in a server-side javascript shell.
 Loading the Interpreter
 -----------------------
 
-To create a PyPy.js interpreter, you must load the file `lib/pypy.js`.  This
-will create the global name `PyPyJS` which can be used to instantiate the
+To create a PyPy.js interpreter, you must load the file `lib/pypyjs.js`.  This
+will create the global name `pypyjs` which can be used to instantiate the
 interpreter.  In the browser::
 
     <!-- shim for ES6 `Promise` builtin -->
     <script src="./lib/Promise.min.js" type="text/javascript"></script>
     <script src="./lib/FunctionPromise.js" type="text/javascript"></script>
-    <script src="./lib/pypy.js" type="text/javascript"></script>
+    <script src="./lib/pypyjs.js" type="text/javascript"></script>
     <script type="text/javascript">
-      var vm = new PyPyJS();
+      var vm = new pypyjs();
       vm.ready.then(function() {
         // this callback is fired when the interpreter is ready for use.
       })
@@ -26,8 +26,8 @@ interpreter.  In the browser::
 
 In nodejs or similar environments::
 
-    const PyPyJS = require("./lib/pypy.js");
-    var vm = new PyPyJS();
+    const pypyjs = require("./lib/pypyjs.js");
+    var vm = new pypyjs();
     vm.ready.then(function() {
       // this callback is fired when the interpreter is ready for use.
     })
@@ -36,13 +36,13 @@ The interpreter API is promise-driven, and loads and initializes its resources
 asynchronously.  You must wait for its `ready` promise to be fulfilled before
 attempting to interact with the interpreter.
 
-It is safe to create multiple `PyPyJS` interpreter objects inside a single
+It is safe to create multiple `pypyjs` interpreter objects inside a single
 javascript interpreter.  They will be completely isolated from each other.
 
 You can customize the behaviour of the interpreter by passing an options
-object to the `PyPyJS` constructor, like this::
+object to the `pypyjs` constructor, like this::
 
-    var vm = new PyPyJS({
+    var vm = new pypyjs({
       totalMemory:  256 * 1024 * 1024,
       stdout: function(data) {
         $('#output').innerHTML += data
@@ -282,13 +282,13 @@ Repository Overview
 ~~~~~~~~~~~~~~~~~~~
 
 +-------------------------+-------------------------------------------------------------------------------------+
-| `pypyjs`_               | Main repository to built a PyPyJS release                                           |
+| `pypyjs`_               | Main repository to built a PyPy.js release                                           |
 +-------------------------+-------------------------------------------------------------------------------------+
 | `pypy`_                 | Fork of PyPy with support for compiling to javascript                               |
 +-------------------------+-------------------------------------------------------------------------------------+
-| `pypyjs-release`_       | Latest release build of PyPyJS, as a handy git submodule                            |
+| `pypyjs-release`_       | Latest release build of PyPy.js, as a handy git submodule                            |
 +-------------------------+-------------------------------------------------------------------------------------+
-| `pypyjs-release-nojit`_ | Latest release build of PyPyJS, without a JIT                                       |
+| `pypyjs-release-nojit`_ | Latest release build of PyPy.js, without a JIT                                       |
 +-------------------------+-------------------------------------------------------------------------------------+
 | `pypyjs-examples`_      | Examples/snippets usage of `pypyjs-release`_ and `pypyjs-release-nojit`_            |
 +-------------------------+-------------------------------------------------------------------------------------+

--- a/README.dist.rst
+++ b/README.dist.rst
@@ -6,20 +6,20 @@ This is a version of the PyPy python interpreter, compiled into javascript
 with emscripten.  It allows you to run a highly-compliant python environment
 in pure javascript, either in a browser or in a server-side javascript shell.
 
-Loading the Interpreter
------------------------
+Using the Interpreter
+---------------------
 
-To create a PyPy.js interpreter, you must load the file `lib/pypyjs.js`.  This
-will create the global name `pypyjs` which can be used to instantiate the
-interpreter.  In the browser::
+To use the PyPy.js interpreter, you must load the file `lib/pypyjs.js`.  This
+will create the global name `pypyjs` which represents the interpreter.
+In the browser::
 
     <!-- shim for ES6 `Promise` builtin -->
     <script src="./lib/Promise.min.js" type="text/javascript"></script>
+    <!-- shim for off-main-thread function compilation -->
     <script src="./lib/FunctionPromise.js" type="text/javascript"></script>
     <script src="./lib/pypyjs.js" type="text/javascript"></script>
     <script type="text/javascript">
-      var vm = new pypyjs();
-      vm.ready.then(function() {
+      pypyjs.ready().then(function() {
         // this callback is fired when the interpreter is ready for use.
       })
     </script>
@@ -27,50 +27,19 @@ interpreter.  In the browser::
 In nodejs or similar environments::
 
     const pypyjs = require("./lib/pypyjs.js");
-    var vm = new pypyjs();
-    vm.ready.then(function() {
+    pypyjs.ready().then(function() {
       // this callback is fired when the interpreter is ready for use.
     })
 
 The interpreter API is promise-driven, and loads and initializes its resources
-asynchronously.  You must wait for its `ready` promise to be fulfilled before
-attempting to interact with the interpreter.
-
-It is safe to create multiple `pypyjs` interpreter objects inside a single
-javascript interpreter.  They will be completely isolated from each other.
-
-You can customize the behaviour of the interpreter by passing an options
-object to the `pypyjs` constructor, like this::
-
-    var vm = new pypyjs({
-      totalMemory:  256 * 1024 * 1024,
-      stdout: function(data) {
-        $('#output').innerHTML += data
-      },
-    });
-
-The available options are:
-
-    * totalMemory:  the amount of heap memory to allocate for the interpreter,
-                    in bytes
-    * stdin:  function to simulate standard input; should return input chars
-              when called.
-    * stdout:  function to simulate standard output; will be called with
-               output chars.
-    * stderr:  function to simulate standard error; will be called with error
-               output chars.
-    * autoLoadModules:  boolean, whether to automatically load module source
-                        files for import statements (see below).
-
-
-Invoking the Interpreter
-------------------------
+asynchronously.  The `ready()` method returns a promise that will be fulfilled
+when it is ready for use.
 
 There are three core methods available for interacting with the interpreter:
 
-* `vm.exec(code)`:  executes python code in the interpreter's global scope.
-* `vm.set(name, value)`:  sets a variable in the interpreter's global scope.
-* `vm.get(name)`:  copy a variable from the interpreter's global scope.
+* `exec(code)`:  executes python code in the interpreter's global scope.
+* `set(name, value)`:  sets a variable in the interpreter's global scope.
+* `get(name)`:  copy a variable from the interpreter's global scope.
 
 Only primitive value types can be retrieved from the interpreter via `get()`.
 This includes python numbers, strings, lists and dicts, but not custom
@@ -79,12 +48,12 @@ objects.
 The following example evaluates a simple arithmetic expression via Python::
 
     function pyDouble(x) {
-      return vm.ready.then(function() {
-        return vm.set('x', x)  // copes the value of 'x' into python
+      return pypyjs.ready().then(function() {
+        return pypyjs.set('x', x)  // copes the value of 'x' into python
       }).then(function() {
-        return vm.exec('x = x * 2');  // doubles the value in 'x' in python
+        return pypyjs.exec('x = x * 2');  // doubles the value in 'x' in python
       }).then(function() {
-        return vm.get('x')  // copies the value in 'x' out to javascript
+        return pypyjs.get('x')  // copies the value in 'x' out to javascript
       });
     }
 
@@ -96,8 +65,8 @@ The following example evaluates a simple arithmetic expression via Python::
 There is also an `eval()` function that evaluates expessions in the global
 scope, similar to python's `eval()`::
 
-    vm.set('x', 7).then(function() {
-      return vm.eval('x * 3');  // evaluates and copies result to javascript
+    pypyjs.set('x', 7).then(function() {
+      return pypyjs.eval('x * 3');  // evaluates and copies result to javascript
     }).then(function(x) {
       console.log(x);  // prints '21'
     });
@@ -106,7 +75,7 @@ scope, similar to python's `eval()`::
 If you have a python code file to execute, the `execfile()` helper method will
 fetch it and pass it to the interpreter for execution::
 
-    vm.execfile("/path/to/some/file.py");
+    pypyjs.execfile("/path/to/some/file.py");
 
 
 If you'd like to simulate an interactive python console, the helper method
@@ -119,12 +88,12 @@ output::
     var terminal = $('#terminal').jqconsole('', '>>> ');
 
     // Hook up output streams to write to the console.
-    vm.stdout = vm.stderr = function(data) {
+    pypyjs.stdout = pypyjs.stderr = function(data) {
       terminal.Write(data, 'jqconsole-output');
     }
 
     // Interact by taking input from the console prompt.
-    vm.repl(function(ps1) {
+    pypyjs.repl(function(ps1) {
 
       // The argument is ">>> " or "... " depending on REPL state.
       jqconsole.SetPromptLabel(ps1);
@@ -152,7 +121,7 @@ of all available modules and what they import in `./lib/modules/index.json`.
 When you execute some python source code containing import statements, like
 this::
 
-    vm.exec("import json; print json.dumps({'hello': 'world'})")
+    pypyjs.exec("import json; print json.dumps({'hello': 'world'})")
 
 The PyPy.js interpreter shell will do the following:
 
@@ -168,13 +137,13 @@ This will usually work transparently, unless your code does any "hidden"
 imports that cannot be easily detected by scanning the code.  For example,
 the following would defeat the import system::
 
-    vm.exec("json = __import__('json')")  // fails with an ImportError
+    pypyjs.exec("json = __import__('json')")  // fails with an ImportError
 
 To work around this limitation, you can force loading of a particular module
 like so::
 
-    vm.loadModuleData("json").then(function() {
-      return vm.exec("json = __import__('json')")  // works fine
+    pypyjs.loadModuleData("json").then(function() {
+      return pypyjs.exec("json = __import__('json')")  // works fine
     });
 
 To add additional python modules to the distribution, use the script
@@ -276,6 +245,51 @@ mapping between the javascript and python objects.  For example::
 Some of these restrictions may be relaxed in future, but they're unlikely to
 go away entirely due to javascript's limited facilities for introspecting the
 garbage collector.
+
+
+Customizing the Interpreter
+---------------------------
+
+You can customize the behaviour of the interpreter by creating a new instance
+of the `pypyjs` object, and passing an options object to the constructor.
+Like this::
+
+    var vm = new pypyjs({
+      totalMemory:  256 * 1024 * 1024,
+      stdout: function(data) {
+        $('#output').innerHTML += data
+      },
+    });
+
+The new instance will be a completely independent interpreter, on which you
+can call all of the methods outlined above::
+
+    vm.ready().then(function() {
+      return vm.set('x', 42)
+    }).then(function() {
+      return vm.exec('x = x * 2')
+    }).then(function() {
+      return vm.get('x')
+    }).then(function(x) {
+      console.log(x);  // prints '84'
+    });
+
+
+It is safe to create multiple `pypyjs` interpreter objects inside a single
+javascript interpreter, and they will be completely isolated from each other.
+
+The available options are:
+
+    * totalMemory:  the amount of heap memory to allocate for the interpreter,
+                    in bytes
+    * stdin:  function to simulate standard input; should return input chars
+              when called.
+    * stdout:  function to simulate standard output; will be called with
+               output chars.
+    * stderr:  function to simulate standard error; will be called with error
+               output chars.
+    * autoLoadModules:  boolean, whether to automatically load module source
+                        files for import statements (see below).
 
 
 Repository Overview

--- a/README.rst
+++ b/README.rst
@@ -29,13 +29,13 @@ Repository Overview
 ~~~~~~~~~~~~~~~~~~~
 
 +-------------------------+-------------------------------------------------------------------------------------+
-| `pypyjs`_               | Main repository to built a PyPyJS release                                           |
+| `pypyjs`_               | Main repository to built a PyPy.js release                                           |
 +-------------------------+-------------------------------------------------------------------------------------+
 | `pypy`_                 | Fork of PyPy with support for compiling to javascript                               |
 +-------------------------+-------------------------------------------------------------------------------------+
-| `pypyjs-release`_       | Latest release build of PyPyJS, as a handy git submodule                            |
+| `pypyjs-release`_       | Latest release build of PyPy.js, as a handy git submodule                            |
 +-------------------------+-------------------------------------------------------------------------------------+
-| `pypyjs-release-nojit`_ | Latest release build of PyPyJS, without a JIT                                       |
+| `pypyjs-release-nojit`_ | Latest release build of PyPy.js, without a JIT                                       |
 +-------------------------+-------------------------------------------------------------------------------------+
 | `pypyjs-examples`_      | Examples/snippets usage of `pypyjs-release`_ and `pypyjs-release-nojit`_            |
 +-------------------------+-------------------------------------------------------------------------------------+

--- a/lib/README.txt
+++ b/lib/README.txt
@@ -1,10 +1,10 @@
 
-This directory contains all the files needed to deploy a basic PyPyJS
+This directory contains all the files needed to deploy a basic pypyjs
 environment.  Specifically, we have:
 
-  * pypy.js:           public-facing API to the PyPy VM
-  * pypy.vm.js:        the PyPy VM itself, as built by rpython+emscripten
-  * pypy.vm.js.lzmem:  compressed memory initializer data for the PyPy VM
+  * pypyjs.js:           public-facing API to the PyPy VM
+  * pypyjs.vm.js:        the PyPy VM itself, as built by rpython+emscripten
+  * pypyks.vm.js.zmem:   compressed memory initializer data for the PyPy VM
 
 And the following dependencies, which are distributed in accordance with their
 open-source license:

--- a/lib/pypyjs.js
+++ b/lib/pypyjs.js
@@ -108,97 +108,108 @@ if (typeof process !== 'undefined') {
 }
 
 
+// Create functions for handling default stdio streams.
+// These will be shared by all VM instances by default.
+//
+// We default stdout and stderr to process outputs if available,
+// printing/logging functions otherwise, and /dev/null if nothing
+// else is available.  Unfortunately there's no good way to read
+// synchronously from stdin in javascript, so that's always /dev/null.
+
 var devNull = {
   stdin: function() { return null; },
   stdout: function() { },
-  stderr: function() { },
+  stderr: function() { }
 }
+
+var stdio = {
+  stdin: null,
+  stdout: null,
+  stderr: null
+}
+
+stdio.stdin = devNull.stdin;
+
+if (typeof process !== "undefined") {
+  if (typeof process.stdout !== "undefined") {
+    stdio.stdout = function(x) { process.stdout.write(x); }
+  }
+  if (typeof process.stderr !== "undefined") {
+    stdio.stderr = function(x) { process.stderr.write(x); }
+  }
+}
+
+var _print, _printErr;
+if (typeof window === "undefined") {
+  // print, printErr from v8, spidermonkey
+  if (typeof print !== "undefined") {
+    _print = print;
+  }
+  if (typeof printErr !== "undefined") {
+    _printErr = printErr;
+  }
+}
+if (typeof console !== "undefined") {
+  if (typeof _print === "undefined") {
+    _print = console.log.bind(console);
+  }
+  if (typeof _printErr === "undefined") {
+    _printErr = console.error.bind(console);
+  }
+}
+
+if (stdio.stdout == null && typeof _print !== "undefined") {
+  // print()/console.log() will add a newline, so we buffer until we
+  // receive one and then let it add it for us.
+  stdio.stdout = (function() {
+    var buffer = [];
+    return function(data) {
+      for (var i = 0; i < data.length; i++) {
+        var x = data.charAt(i);
+        if (x !== "\n") {
+          buffer.push(x);
+        } else {
+          _print(buffer.join(""));
+          buffer.splice(undefined, buffer.length);
+        }
+      }
+    }
+  })();
+}
+
+if (stdio.stderr == null && typeof _printErr !== "undefined") {
+  // printErr()/console.error() will add a newline, so we buffer until we
+  // receive one and then let it add it for us.
+  stdio.stderr = (function() {
+    var buffer = [];
+    return function(data) {
+      for (var i = 0; i < data.length; i++) {
+        var x = data.charAt(i);
+        if (x !== "\n") {
+          buffer.push(x);
+        } else {
+          _printErr(buffer.join(""));
+          buffer.splice(undefined, buffer.length);
+        }
+      }
+    }
+  })();
+}
+
+if (stdio.stdout === null) {
+  stdio.stdout = devNull.stdout;
+}
+
+if (stdio.stderr === null) {
+  stdio.stderr = devNull.stderr;
+}
+
 
 
 // Main class representing the PyPy VM.
 // This is our primary export and return value.
+
 function pypyjs(opts) {
-
-  // Default stdin to a closed file.
-  // There's no good way to synchronously read stdin in javascript.
-  // Calling code may override this to handle stdin.
-  this.stdin = devNull.stdin;
-
-  // Default stdout and stderr to process outputs if available, otherwise
-  // to /dev/null. Calling code may override these to handle output.
-  this.stdout = this.stderr = null
-  if (typeof process !== "undefined") {
-    if (typeof process.stdout !== "undefined") {
-      this.stdout = function(x) { process.stdout.write(x); }
-    }
-    if (typeof process.stderr !== "undefined") {
-      this.stderr = function(x) { process.stderr.write(x); }
-    }
-  }
-  var _print, _printErr;
-  if (typeof window === "undefined") {
-    // print, printErr from v8, spidermonkey
-    if (typeof print !== "undefined") {
-      _print = print;
-    }
-    if (typeof printErr !== "undefined") {
-      _printErr = printErr;
-    }
-  }
-  if (typeof console !== "undefined") {
-    if (typeof _print === "undefined") {
-      _print = console.log.bind(console);
-    }
-    if (typeof _printErr === "undefined") {
-      _printErr = console.error.bind(console);
-    }
-  }
-  if (typeof _print !== "undefined") {
-    if (this.stdout === null) {
-      // print()/console.log() will add a newline, so we buffer until we
-      // receive one and then let it add it for us.
-      this.stdout = (function() {
-        var buffer = [];
-        return function(data) {
-          for (var i = 0; i < data.length; i++) {
-            var x = data.charAt(i);
-            if (x !== "\n") {
-              buffer.push(x);
-            } else {
-              _print(buffer.join(""));
-              buffer.splice(undefined, buffer.length);
-            }
-          }
-        }
-      })();
-    }
-  }
-  if (typeof _printErr !== "undefined") {
-    if (this.stderr === null) {
-      // printErr()/console.error() will add a newline, so we buffer until we
-      // receive one and then let it add it for us.
-      this.stderr = (function() {
-        var buffer = [];
-        return function(data) {
-          for (var i = 0; i < data.length; i++) {
-            var x = data.charAt(i);
-            if (x !== "\n") {
-              buffer.push(x);
-            } else {
-              _printErr(buffer.join(""));
-              buffer.splice(undefined, buffer.length);
-            }
-          }
-        }
-      })();
-    }
-  }
-  if (this.stdout === null) {
-    this.stdout = devNull.stdout;
-  }
-  if (this.stderr === null) {
-    this.stderr = devNull.stderr;
-  }
 
   opts = opts || {};
   this.rootURL = opts.rootURL;
@@ -209,9 +220,9 @@ function pypyjs(opts) {
   this._allModules = {};
 
   // Allow opts to override default IO streams.
-  this.stdin = opts.stdin || this.stdin;
-  this.stdout = opts.stdout || this.stdout;
-  this.stderr = opts.stderr || this.stderr;
+  this.stdin = opts.stdin || stdio.stdin;
+  this.stdout = opts.stdout || stdio.stdout;
+  this.stderr = opts.stderr || stdio.stderr;
 
   // Default to finding files relative to this very file.
   if (!this.rootURL && !pypyjs.rootURL) {
@@ -257,7 +268,7 @@ function pypyjs(opts) {
   // Create a new instance of the compiled VM, bound to local state
   // and a local Module object.
 
-  this.ready = new Promise((function(resolve, reject) {
+  this._ready = new Promise((function(resolve, reject) {
 
     // Initialize the Module object.
     // We make it available on this object so that we can use
@@ -490,6 +501,16 @@ function _escape(value) {
 }
 
 
+// Method to determine when the interpreter is ready.
+//
+// This method returns a promise that will resolve once the interpreter
+// is ready for use.
+//
+pypyjs.prototype.ready = function ready() {
+  return this._ready;
+}
+
+
 // Method to execute some python code.
 //
 // This passes the given python code to the VM for execution.
@@ -498,7 +519,7 @@ function _escape(value) {
 // Rather you should store it into a variable and then use the get() method.
 //
 pypyjs.prototype.exec = function exec(code) {
-  return this.ready.then((function() {
+  return this._ready.then((function() {
     var p = Promise.resolve();
     // Find any "import" statements in the code,
     // and ensure the modules are ready for loading.
@@ -530,7 +551,7 @@ pypyjs.prototype.exec = function exec(code) {
 // This behaviour is deprecated and will be removed in a future release.
 //
 pypyjs.prototype.eval = function eval(expr) {
-  return this.ready.then((function() {
+  return this._ready.then((function() {
     // First try to execute it as an expression.
     code = "r = eval('" + _escape(expr) + "', top_level_scope)";
     return this._execute_source(code);
@@ -581,7 +602,7 @@ pypyjs.prototype.get = function get(name, _fromGlobals) {
   } else {
     var namespace = "top_level_scope";
   }
-  return this.ready.then((function() {
+  return this._ready.then((function() {
     var code = namespace + ".get('" + _escape(name) + "', js.undefined)";
     code = "js.convert(" + code + ")"
     code = "js.globals['pypyjs']._resultsMap['" + resid + "'] = " + code;
@@ -600,7 +621,7 @@ pypyjs.prototype.get = function get(name, _fromGlobals) {
 // python variable to reference it via that handle.
 //
 pypyjs.prototype.set = function set(name, value) {
-  return this.ready.then((function() {
+  return this._ready.then((function() {
     var Module = this._module;
     var h = Module._emjs_make_handle(value);
     name = _escape(name);
@@ -673,7 +694,7 @@ pypyjs.prototype.repl = function repl(prmpt) {
   }
   // Set up an InteractiveConsole instance,
   // then loop forever via recursive promises.
-  return this.ready.then((function() {
+  return this._ready.then((function() {
     return this.loadModuleData("code");
   }).bind(this)).then((function() {
     return this._execute_source("import code");
@@ -770,7 +791,7 @@ pypyjs.prototype.loadModuleData = function loadModuleData(/* names */) {
   // We must find the longest prefix that is an available module
   // and load it along with all its dependencies.
   var modules = Array.prototype.slice.call(arguments);
-  return this.ready.then((function() {
+  return this._ready.then((function() {
     var toLoad = {};
     NEXTNAME: for (var i = 0; i < modules.length; i++) {
       var name = modules[i];
@@ -893,12 +914,37 @@ pypyjs.Error.prototype.constructor = pypyjs.Error;
 // XXX TODO: expose the filesystem for manipulation by calling code.
 
 
+// Add convenience methods directly on the 'pypyjs' function, that
+// will invoke corresponding methods on a default VM instance.
+// This makes it look like 'pypyjs' is a singleton VM instance.
+
+pypyjs._defaultVM = null;
+pypyjs.stdin = stdio.stdin
+pypyjs.stdout = stdio.stdout
+pypyjs.stderr = stdio.stderr
+
+var PUBLIC_NAMES = ['ready', 'exec', 'eval', 'execfile', 'get', 'set',
+                    'repl', 'loadModuleData'];
+
+PUBLIC_NAMES.forEach(function(name) {
+  pypyjs[name] = function() {
+    if (!pypyjs._defaultVM) {
+      pypyjs._defaultVM = new pypyjs({
+        stdin: function(){ return pypyjs.stdin.apply(this, arguments); },
+        stdout: function(){ return pypyjs.stdout.apply(this, arguments); },
+        stderr: function(){ return pypyjs.stderr.apply(this, arguments); },
+      });
+    }
+    return pypyjs._defaultVM[name].apply(pypyjs._defaultVM, arguments)
+  }
+})
+
+
 // For nodejs, run a repl when invoked directly from the command-line.
 
 if (typeof require !== "undefined" && typeof module !== "undefined") {
   if (require.main === module) {
-    var vm = new pypyjs();
-    vm.repl();
+    pypyjs.repl();
   }
 }
 

--- a/lib/pypyjs.js
+++ b/lib/pypyjs.js
@@ -1,20 +1,20 @@
 //
-//  PyPyJS:  an experimental in-browser python environment.
+//  pypyjs:  an experimental in-browser python environment.
 //
 
 (function() {
 
-// Expose the main PyPyJS function at global scope for this file,
+// Expose the main pypyjs function at global scope for this file,
 // as well as in any module exports or 'window' object we can find.
 if (this) {
-  this.PyPyJS = PyPyJS;
+  this.pypyjs = pypyjs;
 }
 if (typeof window !== "undefined") {
-  window.PyPyJS = PyPyJS;
+  window.pypyjs = pypyjs;
 }
 if (typeof module !== "undefined") {
   if (typeof module.exports !== "undefined") {
-    module.exports = PyPyJS;
+    module.exports = pypyjs;
   }
 }
 
@@ -36,7 +36,7 @@ if (typeof __dirname === "undefined") {
   // Throw an error, then parse the stack trace looking for filenames.
   var errlines = (new Error()).stack.split("\n");
   for (var i = 0; i < errlines.length; i++) {
-    var match = /(at Anonymous function \(|at |@)(.+\/)pypy.js/.exec(errlines[i]);
+    var match = /(at Anonymous function \(|at |@)(.+\/)pypyjs.js/.exec(errlines[i]);
     if (match) {
       __dirname = match[2];
       break;
@@ -117,7 +117,7 @@ var devNull = {
 
 // Main class representing the PyPy VM.
 // This is our primary export and return value.
-function PyPyJS(opts) {
+function pypyjs(opts) {
 
   // Default stdin to a closed file.
   // There's no good way to synchronously read stdin in javascript.
@@ -214,8 +214,8 @@ function PyPyJS(opts) {
   this.stderr = opts.stderr || this.stderr;
 
   // Default to finding files relative to this very file.
-  if (!this.rootURL && !PyPyJS.rootURL) {
-    PyPyJS.rootURL = __dirname;
+  if (!this.rootURL && !pypyjs.rootURL) {
+    pypyjs.rootURL = __dirname;
   }
   if (this.rootURL && this.rootURL.charAt(this.rootURL.length - 1) !== "/") {
     this.rootURL += "/";
@@ -225,8 +225,8 @@ function PyPyJS(opts) {
   // We do this once and cache the result for re-use, so that we don't
   // have to pay asmjs compilation overhead each time we create the VM.
 
-  if (! PyPyJS._vmBuilderPromise) {
-    PyPyJS._vmBuilderPromise = this.fetch("pypy.vm.js").then((function(xhr) {
+  if (! pypyjs._vmBuilderPromise) {
+    pypyjs._vmBuilderPromise = this.fetch("pypyjs.vm.js").then((function(xhr) {
       // Parse the compiled code, hopefully asynchronously.
       // Unfortunately our use of Function constructor here doesn't
       // play very well with nodejs, where things like 'module' and
@@ -268,11 +268,11 @@ function PyPyJS(opts) {
 
     // We will set up the filesystem manually when we're ready.
     Module.noFSInit = true;
-    Module.thisProgram = "/lib/pypyjs/pypy.js";
-    Module.filePackagePrefixURL = this.rootURL || PyPyJS.rootURL;
-    Module.memoryInitializerPrefixURL = this.rootURL || PyPyJS.rootURL;
+    Module.thisProgram = "/lib/pypyjs/pypyjs.js";
+    Module.filePackagePrefixURL = this.rootURL || pypyjs.rootURL;
+    Module.memoryInitializerPrefixURL = this.rootURL || pypyjs.rootURL;
     Module.locateFile = function(name) {
-      return (this.rootURL || PyPyJS.rootURL) + name;
+      return (this.rootURL || pypyjs.rootURL) + name;
     }
 
     // Don't start or stop the program, just set it up.
@@ -331,7 +331,7 @@ function PyPyJS(opts) {
     // XXX TODO: also load memory initializer this way.
     var moduleDataP = this.fetch("modules/index.json");
 
-    PyPyJS._vmBuilderPromise.then((function(vmBuilder) {
+    pypyjs._vmBuilderPromise.then((function(vmBuilder) {
       var args = [
         Module,
         dependenciesFulfilled,
@@ -357,7 +357,7 @@ function PyPyJS(opts) {
         // It's finally safe to launch the VM.
         Module.run();
         Module._rpython_startup_code();
-        var pypy_home = Module.intArrayFromString("/lib/pypyjs/pypy.js");
+        var pypy_home = Module.intArrayFromString("/lib/pypyjs/pypyjs.js");
         pypy_home = Module.allocate(pypy_home, 'i8', Module.ALLOC_NORMAL);
         Module._pypy_setup_home(pypy_home, 0);
         Module._free(pypy_home);
@@ -371,11 +371,11 @@ function PyPyJS(opts) {
           var code = Module.intArrayFromString(codeStr);
           var code = Module.allocate(code, 'i8', Module.ALLOC_NORMAL);
           if (!code) {
-            throw new PyPyJS.Error('Failed to allocate memory');
+            throw new pypyjs.Error('Failed to allocate memory');
           }
           var res = Module._pypy_execute_source(code);
           if (res < 0) {
-            throw new PyPyJS.Error('Failed to execute python code');
+            throw new pypyjs.Error('Failed to execute python code');
           }
           Module._free(code);
         });
@@ -388,9 +388,9 @@ function PyPyJS(opts) {
 
 
 // A simple file-fetching wrapper around XMLHttpRequest,
-// that treats paths as relative to the pypy.js root url.
+// that treats paths as relative to the pypyjs.js root url.
 //
-PyPyJS.prototype.fetch = function fetch(relpath, responseType) {
+pypyjs.prototype.fetch = function fetch(relpath, responseType) {
   // For the web, use XMLHttpRequest.
   if (typeof XMLHttpRequest !== "undefined") {
     return new Promise((function(resolve, reject) {
@@ -402,7 +402,7 @@ PyPyJS.prototype.fetch = function fetch(relpath, responseType) {
           resolve(xhr);
         }
       };
-      var rootURL = this.rootURL || PyPyJS.rootURL;
+      var rootURL = this.rootURL || pypyjs.rootURL;
       xhr.open('GET', rootURL + relpath, true);
       xhr.responseType = responseType || "text";
       xhr.send(null);
@@ -411,7 +411,7 @@ PyPyJS.prototype.fetch = function fetch(relpath, responseType) {
   // For nodejs, use fs.readFile.
   if (typeof fs !== "undefined" && typeof fs.readFile !== "undefined") {
     return new Promise((function(resolve, reject) {
-      var rootURL = this.rootURL || PyPyJS.rootURL;
+      var rootURL = this.rootURL || pypyjs.rootURL;
       fs.readFile(path.join(rootURL, relpath), function(err, data) {
         if (err) return reject(err);
         resolve({ responseText: data.toString() });
@@ -421,7 +421,7 @@ PyPyJS.prototype.fetch = function fetch(relpath, responseType) {
   // For spidermonkey, use snarf (which has a binary read mode).
   if (typeof snarf !== "undefined") {
     return new Promise((function(resolve, reject) {
-      var rootURL = this.rootURL || PyPyJS.rootURL;
+      var rootURL = this.rootURL || pypyjs.rootURL;
       var data = snarf(rootURL + relpath);
       resolve({ responseText: data });
     }).bind(this));
@@ -429,7 +429,7 @@ PyPyJS.prototype.fetch = function fetch(relpath, responseType) {
   // For d8, use read() and readbuffer().
   if (typeof read !== "undefined" && typeof readbuffer !== "undefined") {
     return new Promise((function(resolve, reject) {
-      var rootURL = this.rootURL || PyPyJS.rootURL;
+      var rootURL = this.rootURL || pypyjs.rootURL;
       var data = read(rootURL + relpath);
       resolve({ responseText: data });
     }).bind(this));
@@ -442,11 +442,11 @@ PyPyJS.prototype.fetch = function fetch(relpath, responseType) {
 
 // Method to execute python source directly in the VM.
 //
-// This is the basic way to push code into the PyPyJS VM.
+// This is the basic way to push code into the pypyjs VM.
 // Calling code should not use it directly; rather we use it
 // as a primitive to build up a nicer execution API.
 //
-PyPyJS.prototype._execute_source = function _execute_source(code) {
+pypyjs.prototype._execute_source = function _execute_source(code) {
   var Module = this._module;
   code = "try:\n" +
          "  " + code + "\n" +
@@ -456,30 +456,30 @@ PyPyJS.prototype._execute_source = function _execute_source(code) {
          "  err_msg = str(val)\n" +
          "  err_trace = traceback.format_exception(typ, val, tb)\n" +
          "  err_trace = ''.join(err_trace)\n" +
-         "  js.globals['PyPyJS']._lastErrorName = err_name\n" +
-         "  js.globals['PyPyJS']._lastErrorMessage = err_msg\n" +
-         "  js.globals['PyPyJS']._lastErrorTrace = err_trace\n";
+         "  js.globals['pypyjs']._lastErrorName = err_name\n" +
+         "  js.globals['pypyjs']._lastErrorMessage = err_msg\n" +
+         "  js.globals['pypyjs']._lastErrorTrace = err_trace\n";
   var code_chars = Module.intArrayFromString(code);
   var code_ptr = Module.allocate(code_chars, 'i8', Module.ALLOC_NORMAL);
   if (!code_ptr) {
-    return Promise.reject(new PyPyJS.Error("Failed to allocate memory"));
+    return Promise.reject(new pypyjs.Error("Failed to allocate memory"));
   }
   var res = Module._pypy_execute_source(code_ptr);
   Module._free(code_ptr);
   // XXX TODO: races/re-entrancy on _lastError?
-  if (PyPyJS._lastErrorName) {
-    var err = new PyPyJS.Error(
-      PyPyJS._lastErrorName,
-      PyPyJS._lastErrorMessage,
-      PyPyJS._lastErrorTrace
+  if (pypyjs._lastErrorName) {
+    var err = new pypyjs.Error(
+      pypyjs._lastErrorName,
+      pypyjs._lastErrorMessage,
+      pypyjs._lastErrorTrace
     );
-    PyPyJS._lastErrorName = null;
-    PyPyJS._lastErrorMessage = null;
-    PyPyJS._lastErrorTrace = null;
+    pypyjs._lastErrorName = null;
+    pypyjs._lastErrorMessage = null;
+    pypyjs._lastErrorTrace = null;
     return Promise.reject(err);
   }
   if (res < 0) {
-    return Promise.reject(new PyPyJS.Error("Error executing python code"));
+    return Promise.reject(new pypyjs.Error("Error executing python code"));
   }
   return Promise.resolve(null);
 }
@@ -497,7 +497,7 @@ function _escape(value) {
 // It is not possible to directly access the result of the code, if any.
 // Rather you should store it into a variable and then use the get() method.
 //
-PyPyJS.prototype.exec = function exec(code) {
+pypyjs.prototype.exec = function exec(code) {
   return this.ready.then((function() {
     var p = Promise.resolve();
     // Find any "import" statements in the code,
@@ -529,7 +529,7 @@ PyPyJS.prototype.exec = function exec(code) {
 // For backwards-compatibility reasons, it will also evaluate statements.
 // This behaviour is deprecated and will be removed in a future release.
 //
-PyPyJS.prototype.eval = function eval(expr) {
+pypyjs.prototype.eval = function eval(expr) {
   return this.ready.then((function() {
     // First try to execute it as an expression.
     code = "r = eval('" + _escape(expr) + "', top_level_scope)";
@@ -545,7 +545,7 @@ PyPyJS.prototype.eval = function eval(expr) {
       }
       // If that failed, try again via exec().
       if (typeof console !== "undefined") {
-        console.warn("Calling PyPyJS.eval() with statements is deprecated.");
+        console.warn("Calling pypyjs.eval() with statements is deprecated.");
         console.warn("Use eval() for expressions, exec() for statements.");
       }
       return this.exec(expr);
@@ -557,7 +557,7 @@ PyPyJS.prototype.eval = function eval(expr) {
 //
 // This fetches the named file and passes it to the VM for execution.
 //
-PyPyJS.prototype.execfile = function execfile(filename) {
+pypyjs.prototype.execfile = function execfile(filename) {
   return this.fetch(filename).then((function(xhr) {
     var code = xhr.responseText;
     return this.exec(code);
@@ -571,10 +571,10 @@ PyPyJS.prototype.execfile = function execfile(filename) {
 // equivalent javascript value and returns it.  It will fail if the variable
 // does not exist or contains a value that cannot be converted.
 //
-PyPyJS._resultsID = 0;
-PyPyJS._resultsMap = {};
-PyPyJS.prototype.get = function get(name, _fromGlobals) {
-  var resid = ""+(PyPyJS._resultsID++);
+pypyjs._resultsID = 0;
+pypyjs._resultsMap = {};
+pypyjs.prototype.get = function get(name, _fromGlobals) {
+  var resid = ""+(pypyjs._resultsID++);
   // We can read from global scope for internal use; don't do this from calling code!
   if (_fromGlobals) {
     var namespace = "globals()";
@@ -584,11 +584,11 @@ PyPyJS.prototype.get = function get(name, _fromGlobals) {
   return this.ready.then((function() {
     var code = namespace + ".get('" + _escape(name) + "', js.undefined)";
     code = "js.convert(" + code + ")"
-    code = "js.globals['PyPyJS']._resultsMap['" + resid + "'] = " + code;
+    code = "js.globals['pypyjs']._resultsMap['" + resid + "'] = " + code;
     return this._execute_source(code);
   }).bind(this)).then((function() {
-    var res = PyPyJS._resultsMap[resid];
-    delete PyPyJS._resultsMap[resid];
+    var res = pypyjs._resultsMap[resid];
+    delete pypyjs._resultsMap[resid];
     return res;
   }).bind(this));
 }
@@ -599,7 +599,7 @@ PyPyJS.prototype.get = function get(name, _fromGlobals) {
 // This generates a handle to the given object, and arranges for the named
 // python variable to reference it via that handle.
 //
-PyPyJS.prototype.set = function set(name, value) {
+pypyjs.prototype.set = function set(name, value) {
   return this.ready.then((function() {
     var Module = this._module;
     var h = Module._emjs_make_handle(value);
@@ -619,7 +619,7 @@ PyPyJS.prototype.set = function set(name, value) {
 // works fine in e.g. nodejs, but is almost certainly not what you want
 // in the browser, because it's blocking).
 //
-PyPyJS.prototype.repl = function repl(prmpt) {
+pypyjs.prototype.repl = function repl(prmpt) {
   if (!prmpt) {
     // If there's a custom stdin, or we're not in nodejs, then we should
     // default to prompting on stdin/stdout.  For nodejs, we can build
@@ -685,7 +685,7 @@ PyPyJS.prototype.repl = function repl(prmpt) {
 }
 
 
-PyPyJS.prototype._repl_loop = function _repl_loop(prmpt, ps1) {
+pypyjs.prototype._repl_loop = function _repl_loop(prmpt, ps1) {
   return Promise.resolve().then((function() {
     // Prompt for input, which may happen via async promise.
     return prmpt.call(this, ps1);
@@ -731,7 +731,7 @@ PyPyJS.prototype._repl_loop = function _repl_loop(prmpt, ps1) {
 // Perhaps we can call into python's "ast" module for this parsing?
 //
 var importStatementRE = /(from\s+([a-zA-Z0-9_\.]+)\s+)?import\s+\(?\s*([a-zA-Z0-9_\.\*]+(\s+as\s+[a-zA-Z0-9_]+)?[ \t]*,?[ \t]*)+[ \t]*\)?/g
-PyPyJS.prototype.findImportedNames = function findImportedNames(code) {
+pypyjs.prototype.findImportedNames = function findImportedNames(code) {
   var match = null;
   var imports = [];
   importStatementRE.lastIndex = 0;
@@ -765,7 +765,7 @@ PyPyJS.prototype.findImportedNames = function findImportedNames(code) {
 // the VMs simulated filesystem so that is can find and import
 // the specified module.
 //
-PyPyJS.prototype.loadModuleData = function loadModuleData(/* names */) {
+pypyjs.prototype.loadModuleData = function loadModuleData(/* names */) {
   // Each argument is a name that we want to import.
   // We must find the longest prefix that is an available module
   // and load it along with all its dependencies.
@@ -796,7 +796,7 @@ PyPyJS.prototype.loadModuleData = function loadModuleData(/* names */) {
 }
 
 
-PyPyJS.prototype._findModuleDeps = function _findModuleDeps(name, seen) {
+pypyjs.prototype._findModuleDeps = function _findModuleDeps(name, seen) {
   if (!seen) seen = {};
   var deps = [];
   // If we don't know about this module, ignore it.
@@ -830,7 +830,7 @@ PyPyJS.prototype._findModuleDeps = function _findModuleDeps(name, seen) {
 }
 
 
-PyPyJS.prototype._makeLoadModuleData = function _makeLoadModuleData(name) {
+pypyjs.prototype._makeLoadModuleData = function _makeLoadModuleData(name) {
   return (function() {
     // If we've already loaded this module, we're done.
     if (this._loadedModules[name]) {
@@ -858,7 +858,7 @@ PyPyJS.prototype._makeLoadModuleData = function _makeLoadModuleData(name) {
 }
 
 
-PyPyJS.prototype._writeModuleFile = function _writeModuleFile(name, data) {
+pypyjs.prototype._writeModuleFile = function _writeModuleFile(name, data) {
   var Module = this._module;
   var file = this._allModules[name].file;
   // Create the containing directory first.
@@ -876,17 +876,17 @@ PyPyJS.prototype._writeModuleFile = function _writeModuleFile(name, data) {
 // An error class for reporting python exceptions back to calling code.
 // XXX TODO: this could be a lot more user-friendly than a opaque error...
 
-PyPyJS.Error = function PyPyJSError(name, message, trace) {
+pypyjs.Error = function pypyjsError(name, message, trace) {
   if (name && typeof message === "undefined") {
     message = name;
     name = "";
   }
-  this.name = name || "PyPyJS.Error";
-  this.message = message || "PyPyJS Unknown Error";
+  this.name = name || "pypyjs.Error";
+  this.message = message || "pypyjs Unknown Error";
   this.trace = trace || "";
 }
-PyPyJS.Error.prototype = new Error();
-PyPyJS.Error.prototype.constructor = PyPyJS.Error;
+pypyjs.Error.prototype = new Error();
+pypyjs.Error.prototype.constructor = pypyjs.Error;
 
 
 
@@ -897,11 +897,11 @@ PyPyJS.Error.prototype.constructor = PyPyJS.Error;
 
 if (typeof require !== "undefined" && typeof module !== "undefined") {
   if (require.main === module) {
-    var vm = new PyPyJS();
+    var vm = new pypyjs();
     vm.repl();
   }
 }
 
-return PyPyJS;
+return pypyjs;
 
 })();

--- a/lib/tests/index.html
+++ b/lib/tests/index.html
@@ -10,10 +10,10 @@
 
   <script src="../Promise.min.js" type="text/javascript" charset="utf-8"></script>
   <script src="../FunctionPromise.js" type="text/javascript" charset="utf-8"></script>
-  <script src="../pypy.js" type="text/javascript" charset="utf-8"></script>
+  <script src="../pypyjs.js" type="text/javascript" charset="utf-8"></script>
   <script src="./tests.js" type="text/javascript" charset="utf-8"></script>
   <script>
-      PyPyJSTestResult.then(function() {
+      pypyjsTestResult.then(function() {
         document.getElementById("results").innerHTML = "Tests passed";
       }, function(err) {
         document.getElementById("results").innerHTML = "Tests failed: " + err;

--- a/lib/tests/tests.js
+++ b/lib/tests/tests.js
@@ -22,13 +22,11 @@ if (typeof console !== 'undefined') {
   log = print;
 }
 
-var vm = new pypyjs();
-
-var pypyjsTestResult = vm.ready
+var pypyjsTestResult = pypyjs.ready()
 
 // First, check that python-level errors will actually fail the tests.
 .then(function() {
-  return vm.exec("raise ValueError(42)");
+  return pypyjs.exec("raise ValueError(42)");
 })
 .then(function() {
   throw new Error("Python exception did not trigger js Error");
@@ -43,13 +41,13 @@ var pypyjsTestResult = vm.ready
 
 // Check that the basic set-exec-get cycle works correctly.
 .then(function() {
-  return vm.set("x", 7);
+  return pypyjs.set("x", 7);
 })
 .then(function() {
-  return vm.exec("x = x * 2");
+  return pypyjs.exec("x = x * 2");
 })
 .then(function() {
-  return vm.get("x");
+  return pypyjs.get("x");
 })
 .then(function(x) {
   if (x !== 14) {
@@ -59,7 +57,7 @@ var pypyjsTestResult = vm.ready
 
 // Check that eval() works correctly.
 .then(function() {
-  return vm.eval("x + 1");
+  return pypyjs.eval("x + 1");
 })
 .then(function(x) {
   if (x !== 15) {
@@ -69,7 +67,7 @@ var pypyjsTestResult = vm.ready
 
 // Check that we can read non-existent names and get 'undefined'
 .then(function() {
-  return vm.get("nonExistentName")
+  return pypyjs.get("nonExistentName")
 })
 .then(function(x) {
   if (typeof x !== "undefined") {
@@ -79,20 +77,20 @@ var pypyjsTestResult = vm.ready
 
 // Check that we execute in correctly-__name__'d python scope.
 .then(function() {
-  return vm.exec("assert __name__ == '__main__', __name__")
+  return pypyjs.exec("assert __name__ == '__main__', __name__")
 })
 
 // Check that sys.platform tells us something sensible.
 .then(function() {
-  return vm.exec("import sys; assert sys.platform == 'js'");
+  return pypyjs.exec("import sys; assert sys.platform == 'js'");
 })
 
 // Check that multi-line exec will work correctly.
 .then(function() {
-  return vm.exec("x = 2\ny = x * 3");
+  return pypyjs.exec("x = 2\ny = x * 3");
 })
 .then(function() {
-  return vm.get("y")
+  return pypyjs.get("y")
 })
 .then(function(y) {
   if (y !== 6) {
@@ -102,15 +100,33 @@ var pypyjsTestResult = vm.ready
 
 // Check that multi-import statements will work correctly.
 .then(function() {
-  return vm.exec("import os\nimport time\nimport sys\nx=time.time()")
+  return pypyjs.exec("import os\nimport time\nimport sys\nx=time.time()")
 })
 .then(function() {
-  return vm.get("x")
+  return pypyjs.get("x")
 })
 .then(function(x) {
   if (!x) {
     throw new Error("multi-line import didn't work");
   }
+})
+
+// Check that you can create additional VMs using `new`
+.then(function() {
+  var vm = new pypyjs()
+  return vm.exec("x = 17").then(function() {
+    return vm.get("x")
+  }).then(function(x) {
+    if (x !== 17) {
+      throw new Error("newly-created VM didn't work right")
+    }
+  }).then(function() {
+    return vm.get("y")
+  }).then(function(y) {
+    if (typeof y !== "undefined") {
+      throw new Error("name should have been undefined in new VM");
+    }
+  })
 })
 
 // Report success or failure at the end of the chain.

--- a/lib/tests/tests.js
+++ b/lib/tests/tests.js
@@ -3,15 +3,15 @@
 // We should do something a lot nicer than this...
 //
 
-var PyPyJS;
-if (typeof PyPyJS === 'undefined') {
+var pypyjs;
+if (typeof pypyjs === 'undefined') {
   
   if (typeof require !== 'undefined') {
-    PyPyJS = require('../pypy.js');
+    pypyjs = require('../pypyjs.js');
   } else if (typeof loadRelativeToScript !== 'undefined') {
-    loadRelativeToScript('../pypy.js');
+    loadRelativeToScript('../pypyjs.js');
   } else if (typeof load !== 'undefined') {
-    load('pypy.js');
+    load('pypyjs.js');
   }
 }
 
@@ -22,9 +22,9 @@ if (typeof console !== 'undefined') {
   log = print;
 }
 
-var vm = new PyPyJS();
+var vm = new pypyjs();
 
-var PyPyJSTestResult = vm.ready
+var pypyjsTestResult = vm.ready
 
 // First, check that python-level errors will actually fail the tests.
 .then(function() {
@@ -33,8 +33,8 @@ var PyPyJSTestResult = vm.ready
 .then(function() {
   throw new Error("Python exception did not trigger js Error");
 }, function(err) {
-  if (! err instanceof PyPyJS.Error) {
-    throw new Error("Python exception didn't trigger PyPyJS.Error instance");
+  if (! err instanceof pypyjs.Error) {
+    throw new Error("Python exception didn't trigger pypyjs.Error instance");
   }
   if (err.name !== "ValueError" || err.message !== "42") {
     throw new Error("Python exception didn't trigger correct error info");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pypyjs",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "author": "Ryan Kelly <ryan@rfk.id.au>",
   "description": "The PyPy Python VM, in JavaScript",
   "keywords": ["python", "pypy", "asmjs", "emscripten", "wtf"],
@@ -10,7 +10,7 @@
   },
   "homepage": "http://pypyjs.org/",
   "bugs": "https://github.com/pypyjs/pypyjs/issues/",
-  "main": "./lib/pypy.js",
+  "main": "./lib/pypyjs.js",
   "files": [
     "lib/",
     "tools/",


### PR DESCRIPTION
Fixes #147.

@jedie @crantila here's a first attempt at simplifying some of the naming weirdness we've got going on in the project at the moment.  I'm currently trying out a build to make sure I haven't broken anything.  Thoughts?

I'm not sure I like losing the capitalization in `new PyPyJS() => new pypyjs()` but I can live with it.  The rest of it I think is definitely an improvement.
