### PR TITLE
load modules in parallel

### DIFF
--- a/lib/pypyjs.js
+++ b/lib/pypyjs.js
@@ -807,12 +807,11 @@ pypyjs.prototype.loadModuleData = function loadModuleData(/* names */) {
       this._findModuleDeps(name, toLoad);
     } 
     // Now ensure that each module gets loaded.
-    // XXX TODO: we could load these concurrently.
-    var p = Promise.resolve();
+    var loadPromises = [];
     for (var name in toLoad) {
-      p = p.then(this._makeLoadModuleData(name));
+      loadPromises.push(this._makeLoadModuleData(name)());
     }
-    return p;
+    return Promise.all(loadPromises);
   }).bind(this));
 }
 


### PR DESCRIPTION
When you import `unittest` it goes off and download around 50 py files. This uses the `Promise.all` function to load then in parallel 